### PR TITLE
Feature Default limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-anywhere-mongodb",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Use graphql to query mongodb",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",

--- a/src/mongo-graphql-client.ts
+++ b/src/mongo-graphql-client.ts
@@ -34,6 +34,13 @@ export interface GraphQLMongoClientOptions {
    * }
    */
   formatError?: ErrorFormatter;
+
+  /**
+   * If no limit clause is passed, this default limit will be used. This is to prevent
+   * someone accidentally pulling in thousands or millions of mongo documents by mistake.
+   * Defaults to 100 if not passed.
+   */
+  defaultLimit?: number;
 }
 
 /**
@@ -74,6 +81,16 @@ export interface QueryResult {
    * Errors that occurred during the process (if any).
    */
   errors?: any[];
+
+  /**
+   * Metadata about each collection query such as the limit applied and offset.
+   */
+  _meta?: {
+    [collection: string]: {
+      limit?: number;
+      offset?: number;
+    }
+  }
 }
 
 /**
@@ -85,6 +102,7 @@ export class MongoGraphQLClient {
   private readonly whitelist: string[];
   private readonly includeStack: boolean;
   private readonly errorFormatter: ErrorFormatter;
+  private readonly defaultLimit: number;
 
   /**
    * Create a new {MongoGraphQLClient}.
@@ -102,6 +120,9 @@ export class MongoGraphQLClient {
       .map(collection => collection.toLowerCase());
     this.includeStack = options.includeStack === true;
     this.errorFormatter = options.formatError || defaultErrorFormatter;
+    this.defaultLimit = typeof options.defaultLimit === 'number'
+      ? options.defaultLimit
+      : 100;
 
     log('Mongo GraphQL client initialized with options', {
       database: this.connection.databaseName,
@@ -122,7 +143,11 @@ export class MongoGraphQLClient {
   async find(query: DocumentNode | string, variables?: object): Promise<QueryResult> {
     // Convert graphql to info about how to execute query
     const document = parseDocument(query);
-    const queryInfos = graphqlToMongo(document, variables);
+    const queryInfos = graphqlToMongo(document, variables)
+
+    // Default limit on query infos if not passed
+    queryInfos
+      .forEach(info => info.limit = typeof info.limit === 'number' ? info.limit : this.defaultLimit);
 
     // Check collections against whitelist
     if (this.whitelist.length) {
@@ -148,7 +173,14 @@ export class MongoGraphQLClient {
         ...obj,
         [result.collection]: result.results
       }), {}),
-      errors: !errors.length ? undefined : errors
+      errors: !errors.length ? undefined : errors,
+      _meta: queryInfos.reduce((obj, info) => ({
+        ...obj,
+        [info.collection]: {
+          limit: info.limit,
+          skip: info.skip
+        }
+      }), {})
     }
   }
 


### PR DESCRIPTION
Added ability to set `defaultLimit` and `maxLimit` on mongo queries when configuring client.
This is to prevent accidentally allowing users to DDoS their mongodb with long un-capped queries.
Also added the ability to set a `maxLimit` that will serve as a hard upper-bound on `limit`. Any queries with a `limit` greater than that will throw an error.